### PR TITLE
Support ruby 1.8.7

### DIFF
--- a/emoji.rb
+++ b/emoji.rb
@@ -22,7 +22,7 @@ query = Regexp.escape(ARGV.first).delete(':')
 related_matches = RELATED_WORDS.select { |k, v| match?(k, query) || v.any? { |r| match?(r, query) } }
 # Support 1.9+ and 1.8.7.
 # 1.8.7 returns a ['key', ['value', 'values']] instead of a hash. Stupid.
-related_matches = related_matches.respond_to?(:keys) ? related_matches.keys : related_matches.map { |match| match[0] }
+related_matches = related_matches.respond_to?(:keys) ? related_matches.keys : related_matches.map(&:first)
 
 image_matches = Dir["#{images_path}/*.png"].map { |fn| File.basename(fn, '.png') }.select { |fn| match?(fn, query) }
 


### PR DESCRIPTION
Ruby 1.8.7 is still the system default in Mountain Lion. It's not too much of a problem to support it to.
