### PR TITLE
support spaces in search

### DIFF
--- a/emoji.rb
+++ b/emoji.rb
@@ -12,7 +12,7 @@ def item_xml(options = {})
 end
 
 def match?(word, query)
-  word.match(/#{query.split('').join('.*')}/i)
+  word.match(/#{query.gsub(/\\ /, '').split('').join('.*')}/i)
 end
 
 images_path = File.expand_path('../images/emoji', __FILE__)


### PR DESCRIPTION
When I type in a space for search, the emoji filter stops working.

This removes the space escaping and the space as well.

Thanks,
